### PR TITLE
[BUG]: Make sure hnsw_cache_size is never zero to avoid seg fault 

### DIFF
--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -75,11 +75,8 @@ class RustBindingsAPI(ServerAPI):
             max_file_handles = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
         else:
             max_file_handles = ctypes.windll.msvcrt._getmaxstdio()  # type: ignore
-        self.hnsw_cache_size = (
-            max_file_handles
-            # This is integer division in Python 3, and not a comment.
-            # Each HNSW index has 4 data files and 1 metadata file
-            // 5
+        # Calculate cache size with a minimum value of 1 to avoid segmentation fault
+        self.hnsw_cache_size = max(1, max_file_handles // 5)
         )
 
     @override


### PR DESCRIPTION
## Description of changes
The segmentation fault is caused by a zero-capacity cache configuration in the Rust bindings when the system has very limited file handles available.

Fixes https://github.com/chroma-core/chroma/issues/4460

_Summarize the changes made by this PR._
This PR ensures that we initialize `hnsw_cache_size` to at least 1, when limited handles are available.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
